### PR TITLE
Change node-sass from 3.3.3 to 3.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "1.8.0",
     "mocha": "~2.3.0",
-    "node-sass": "~3.3.3",
+    "node-sass": "~3.11.2",
     "raw-loader": "~0.5.1",
     "rimraf": "~2.5.2",
     "sass-loader": "~3.0.0",


### PR DESCRIPTION
3.3.3 was giving masses of errors. Only solution was to change node-sass to latest version.
Node-sass has to be the flakiest package on npm.